### PR TITLE
Fix bad Lotka-Volterra "d" parameter

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -6381,7 +6381,7 @@ initial values $R(0)$ and $F(0)$, and the output is a matrix
 that contains one column for $R$ and one for $F$.
 
 And here's what the rate function looks like
-with the parameters $a = 0.1$, $b = 0.01$, $c = 0.1$, and $d = 0.02$:
+with the parameters $a = 0.1$, $b = 0.01$, $c = 0.1$, and $d = 0.002$:
 
 \begin{verbatim}
 function res = lotka(t, V)
@@ -6393,7 +6393,7 @@ function res = lotka(t, V)
     a = 0.1;
     b = 0.01;
     c = 0.1;
-    d = 0.02;
+    d = 0.002;
 
     % compute the derivatives
     drdt = a*r - b*r*f;

--- a/code/chpt09_systems_of_odes/lotka.m
+++ b/code/chpt09_systems_of_odes/lotka.m
@@ -7,11 +7,11 @@ function res = lotka(t, V)
     a = 0.1;
     b = 0.01;
     c = 0.1;
-    e = 0.2;
+    d = 0.002;
 
     % compute the derivatives
     drdt = a*r - b*r*f;
-    dfdt = e*b*r*f - c*f;
+    dfdt = -c*f + d*r*f;
 
     % pack the derivatives into a vector
     res = [drdt; dfdt];


### PR DESCRIPTION
As @scratchley noted in an email:

> Hi
> 
> So in Lotka equation 9.2 on page 85 of version 2.1.0 of Physical Modeling in MATLAB, Matt substituted in a parameter d replacing the multiplication of Allen's parameters e and b.  See Matt's prior comments in the email below. 
> 
> However, to keep the figure looking the same, Matt's parameter d should have been initialized to 0.01 x 0.2 = 0.002 instead of the 0.02 shown in that version of the book.
> 
> I've done a bit more research on this, and found the following link:
> 
>       https://mathinsight.org/introducing_rabbit_predators
> 
> This link shows parameters defined similarly to what Allen had used,  naming as delta Matt's variable d, and defining delta as "δ (delta) captures how efficiently the eaten rabbits are turned into new foxes. (Since each rabbit consumed doesn't lead to a new fox, you expect thatδ should be quite a bit smaller thanβ.) "
> 
> In the link, delta stands on it's own, like Matt's d, and is not multiplied by any other parameter.  I suggest we fix the initialization of parameter d as I describe above.  We can perhaps put the definitions of the parameters back into the text, following the above link (or the attached PDF from Matt). 
> 
> Furthermore, the development by Moler is interesting in:
> 
>      https://www.mathworks.com/content/dam/mathworks/mathworks-dot-com/moler/exm/chapters/predprey.pdf
> 
> Moler uses only the initial conditions and two other parameters.
> 
> Thanks, Dimitrios, for pointing out the discrepancy. 
> 
>  Craig
> 

This PR fixes the incorrect value of "d".

Thanks Dimitrios!